### PR TITLE
Drop unnecessary path prefix and export-ignore completion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,10 @@
-/test               export-ignore
-/.coveralls.yml     export-ignore
-/.gitattributes     export-ignore
-/.gitignore         export-ignore
-/.php_cs            export-ignore
-/.travis.yml        export-ignore
-/phpunit.xml.dist   export-ignore
+.editorconfig      export-ignore
+.gitattributes     export-ignore
+.gitignore         export-ignore
+.php_cs.dist       export-ignore
+.travis.yml        export-ignore
+CONTRIBUTING.md    export-ignore
+Makefile           export-ignore
+phpunit.xml.dist   export-ignore
+README.md          export-ignore
+test/              export-ignore

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,6 +1,9 @@
 <?php
 
+$cacheDir = getenv("TRAVIS") ? getenv("HOME") . "/.php-cs-fixer" : __DIR__;
+
 return PhpCsFixer\Config::create()
+    ->setCacheFile($cacheDir . "/.php_cs.cache")
     ->setRiskyAllowed(true)
     ->setRules([
         "@PSR1" => true,
@@ -36,4 +39,5 @@ return PhpCsFixer\Config::create()
         PhpCsFixer\Finder::create()
             ->in(__DIR__ . "/lib")
             ->in(__DIR__ . "/test")
-    );
+            ->exclude(__DIR__ . "/vendor")
+);

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 before_script:
   # --ignore-platform-reqs, because https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2722
   - composer update -n --prefer-dist --ignore-platform-reqs
-  - composer require satooshi/php-coveralls dev-master --ignore-platform-reqs
+  - composer require satooshi/php-coveralls '^2.0' --ignore-platform-reqs
 
 script:
   - phpdbg -qrr vendor/bin/phpunit --coverage-text --coverage-clover build/logs/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,4 @@ after_script:
 cache:
   directories:
     - $HOME/.composer/cache/files
+    - $HOME/.php-cs-fixer


### PR DESCRIPTION
Completed the list of files to exclude from releases/distributions. The `LICENSE` file might be excluded from that list of files, but that's up to your liking. 

I'm also not quite sure if the `Makefile` is also required for the package itself in which case it should be excluded from that list.