### PR TITLE
Fix file cache

### DIFF
--- a/lib/FileCache.php
+++ b/lib/FileCache.php
@@ -73,6 +73,8 @@ final class FileCache implements Cache
         Loop::defer($gcWatcher);
 
         $this->gcWatcher = Loop::repeat(300000, $gcWatcher);
+
+        Loop::unreference($this->gcWatcher);
     }
 
     public function __destruct()


### PR DESCRIPTION
following this example https://github.com/amphp/cache/blob/v2/lib/ArrayCache.php#L60
I added the same in `lib/FileCache.php` otherwise I'm getting an infinity loop when I configure MySQL pool like
```
new AmpMySql\Pool(
			$config,
			ConnectionPool::DEFAULT_MAX_CONNECTIONS,
			ConnectionPool::DEFAULT_IDLE_TIMEOUT,
			new CancellableConnector(
				new DnsConnector(
					new Rfc1035StubResolver(
						new FileCache(
							JPATH_ROOT . '/cache',
							new LocalKeyedMutex
						)
					)
				)
			)
```
By the way, using `ArrayCache` is faster, is there any tip to speed up DNS resolver initiation?