### PR TITLE
Separate StringCache and Cache interface

### DIFF
--- a/src/AtomicCache.php
+++ b/src/AtomicCache.php
@@ -11,16 +11,16 @@ use Amp\Sync\Lock;
  */
 final class AtomicCache
 {
-    /** @var SerializedCache<TValue> */
-    private SerializedCache $cache;
+    /** @var Cache<TValue> */
+    private Cache $cache;
 
     private KeyedMutex $mutex;
 
     /**
-     * @param SerializedCache<TValue> $cache
+     * @param Cache<TValue> $cache
      * @param KeyedMutex $mutex
      */
-    public function __construct(SerializedCache $cache, KeyedMutex $mutex)
+    public function __construct(Cache $cache, KeyedMutex $mutex)
     {
         $this->cache = $cache;
         $this->mutex = $mutex;

--- a/src/LocalCache.php
+++ b/src/LocalCache.php
@@ -22,7 +22,7 @@ final class LocalCache implements Cache
         // instance and the event loop callback. Otherwise, this object could only be collected when the garbage
         // collection callback was cancelled at the event loop layer.
         $this->state = $state = new class {
-            /** @var string[] */
+            /** @var array */
             public array $cache = [];
             /** @var int[] */
             public array $cacheTimeouts = [];
@@ -65,7 +65,7 @@ final class LocalCache implements Cache
         EventLoop::cancel($this->gcCallbackId);
     }
 
-    public function get(string $key): ?string
+    public function get(string $key): mixed
     {
         if (!isset($this->state->cache[$key])) {
             return null;
@@ -83,8 +83,12 @@ final class LocalCache implements Cache
         return $this->state->cache[$key];
     }
 
-    public function set(string $key, string $value, int $ttl = null): void
+    public function set(string $key, mixed $value, int $ttl = null): void
     {
+        if ($value === null) {
+            throw new CacheException('Cannot store NULL in ' . self::class);
+        }
+
         if ($ttl === null) {
             unset($this->state->cacheTimeouts[$key]);
         } elseif ($ttl >= 0) {

--- a/src/NullCache.php
+++ b/src/NullCache.php
@@ -12,7 +12,7 @@ final class NullCache implements Cache
         return null;
     }
 
-    public function set(string $key, string $value, int $ttl = null): void
+    public function set(string $key, mixed $value, int $ttl = null): void
     {
         // Nothing to do.
     }

--- a/src/PrefixCache.php
+++ b/src/PrefixCache.php
@@ -28,7 +28,7 @@ final class PrefixCache implements Cache
         return $this->cache->get($this->keyPrefix . $key);
     }
 
-    public function set(string $key, string $value, int $ttl = null): void
+    public function set(string $key, mixed $value, int $ttl = null): void
     {
         $this->cache->set($this->keyPrefix . $key, $value, $ttl);
     }

--- a/src/SerializedCache.php
+++ b/src/SerializedCache.php
@@ -8,13 +8,13 @@ use Amp\Serialization\Serializer;
 /**
  * @template TValue
  */
-final class SerializedCache
+final class SerializedCache implements Cache
 {
-    private Cache $cache;
+    private StringCache $cache;
 
     private Serializer $serializer;
 
-    public function __construct(Cache $cache, Serializer $serializer)
+    public function __construct(StringCache $cache, Serializer $serializer)
     {
         $this->cache = $cache;
         $this->serializer = $serializer;
@@ -30,7 +30,7 @@ final class SerializedCache
      * @throws CacheException
      * @throws SerializationException
      *
-     * @see Cache::get()
+     * @see StringCache::get()
      */
     public function get(string $key): mixed
     {
@@ -53,12 +53,12 @@ final class SerializedCache
      * @throws CacheException
      * @throws SerializationException
      *
-     * @see Cache::set()
+     * @see StringCache::set()
      */
     public function set(string $key, mixed $value, ?int $ttl = null): void
     {
         if ($value === null) {
-            throw new CacheException('Cannot store NULL in serialized cache');
+            throw new CacheException('Cannot store NULL in ' . self::class);
         }
 
         $value = $this->serializer->serialize($value);
@@ -76,7 +76,7 @@ final class SerializedCache
      *
      * @throws CacheException
      *
-     * @see Cache::delete()
+     * @see StringCache::delete()
      */
     public function delete(string $key): ?bool
     {

--- a/src/StringCache.php
+++ b/src/StringCache.php
@@ -2,10 +2,7 @@
 
 namespace Amp\Cache;
 
-/**
- * @template TValue
- */
-interface Cache
+interface StringCache
 {
     /**
      * Gets a value associated with the given key.
@@ -14,11 +11,11 @@ interface Cache
      *
      * @param $key string Cache key.
      *
-     * @return TValue|null Returns the cached value, or {@code null} if it doesn't exist
+     * @return string|null Returns the cached value, or {@code null} if it doesn't exist
      *
      * @throws CacheException On failure to determine the cached value
      */
-    public function get(string $key): mixed;
+    public function get(string $key): ?string;
 
     /**
      * Sets a value associated with the given key. Overrides existing values (if they exist).
@@ -26,12 +23,12 @@ interface Cache
      * TTL values less than 0 MUST throw an \Error.
      *
      * @param $key string Cache key.
-     * @param $value TValue Value to cache.
+     * @param $value string Value to cache.
      * @param $ttl int Timeout in seconds >= 0. The default {@code null} $ttl value indicates no timeout.
      *
      * @throws CacheException On failure to store the cached value
      */
-    public function set(string $key, mixed $value, int $ttl = null): void;
+    public function set(string $key, string $value, int $ttl = null): void;
 
     /**
      * Deletes a value associated with the given key if it exists.

--- a/src/StringCacheAdapter.php
+++ b/src/StringCacheAdapter.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Amp\Cache;
+
+final class StringCacheAdapter implements StringCache
+{
+    private Cache $cache;
+
+    public function __construct(Cache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    public function get(string $key): ?string
+    {
+        $value = $this->cache->get($key);
+
+        if ($value !== null && !\is_string($value)) {
+            throw new CacheException(
+                'Received unexpected type from ' . \get_class($this->cache) . ': ' . \get_debug_type($value)
+            );
+        }
+
+        return $value;
+    }
+
+    public function set(string $key, string $value, int $ttl = null): void
+    {
+        $this->cache->set($key, $value, $ttl);
+    }
+
+    public function delete(string $key): ?bool
+    {
+        return $this->cache->delete($key);
+    }
+}

--- a/test/AtomicCacheTest.php
+++ b/test/AtomicCacheTest.php
@@ -5,10 +5,7 @@ namespace Amp\Cache\Test;
 use Amp\Cache\AtomicCache;
 use Amp\Cache\CacheException;
 use Amp\Cache\LocalCache;
-use Amp\Cache\SerializedCache;
 use Amp\PHPUnit\AsyncTestCase;
-use Amp\Serialization\NativeSerializer;
-use Amp\Serialization\PassthroughSerializer;
 use Amp\Sync\KeyedMutex;
 use Amp\Sync\LocalKeyedMutex;
 use function Amp\async;
@@ -20,7 +17,7 @@ class AtomicCacheTest extends AsyncTestCase
     {
         $this->setMinimumRuntime(0.1);
 
-        $internalCache = new SerializedCache(new LocalCache, new PassthroughSerializer);
+        $internalCache = new LocalCache;
         $atomicCache = new AtomicCache($internalCache, new LocalKeyedMutex);
 
         $callback = function (string $key): string {
@@ -37,7 +34,7 @@ class AtomicCacheTest extends AsyncTestCase
 
     public function testComputeIfAbsentWhenValueExists(): void
     {
-        $internalCache = new SerializedCache(new LocalCache, new PassthroughSerializer);
+        $internalCache = new LocalCache;
         $atomicCache = new AtomicCache($internalCache, new LocalKeyedMutex);
 
         $internalCache->set('key', 'value');
@@ -50,7 +47,7 @@ class AtomicCacheTest extends AsyncTestCase
 
     public function testComputeIfPresentWhenValueAbsent(): void
     {
-        $internalCache = new SerializedCache(new LocalCache, new PassthroughSerializer);
+        $internalCache = new LocalCache;
         $atomicCache = new AtomicCache($internalCache, new LocalKeyedMutex);
 
         $result = $atomicCache->computeIfPresent('key', $this->createCallback(0));
@@ -62,7 +59,7 @@ class AtomicCacheTest extends AsyncTestCase
     {
         $this->setMinimumRuntime(0.1);
 
-        $internalCache = new SerializedCache(new LocalCache, new PassthroughSerializer);
+        $internalCache = new LocalCache;
         $atomicCache = new AtomicCache($internalCache, new LocalKeyedMutex);
 
         $internalCache->set('key', 'value');
@@ -83,7 +80,7 @@ class AtomicCacheTest extends AsyncTestCase
     {
         $this->setMinimumRuntime(0.1);
 
-        $internalCache = new SerializedCache(new LocalCache, new PassthroughSerializer);
+        $internalCache = new LocalCache;
         $atomicCache = new AtomicCache($internalCache, new LocalKeyedMutex);
 
         $internalCache->set('key', 'original');
@@ -102,7 +99,7 @@ class AtomicCacheTest extends AsyncTestCase
 
     public function testComputeCallbackThrowing(): void
     {
-        $cache = new AtomicCache(new SerializedCache(new LocalCache, new PassthroughSerializer), new LocalKeyedMutex);
+        $cache = new AtomicCache(new LocalCache, new LocalKeyedMutex);
 
         $this->expectException(CacheException::class);
         $this->expectExceptionMessage('Exception thrown while creating');
@@ -116,7 +113,7 @@ class AtomicCacheTest extends AsyncTestCase
     {
         $this->setMinimumRuntime(0.5);
 
-        $internalCache = new SerializedCache(new LocalCache, new PassthroughSerializer);
+        $internalCache = new LocalCache;
         $atomicCache = new AtomicCache($internalCache, new LocalKeyedMutex);
 
         $callback = function (string $key): string {
@@ -139,7 +136,7 @@ class AtomicCacheTest extends AsyncTestCase
         $this->setMinimumRuntime(0.5);
         $this->setTimeout(0.6);
 
-        $internalCache = new SerializedCache(new LocalCache, new PassthroughSerializer);
+        $internalCache = new LocalCache;
         $atomicCache = new AtomicCache($internalCache, new LocalKeyedMutex);
 
         $callback = function (string $key): string {
@@ -162,7 +159,7 @@ class AtomicCacheTest extends AsyncTestCase
         $this->setMinimumRuntime(1);
         $this->setTimeout(1.3);
 
-        $internalCache = new SerializedCache(new LocalCache, new NativeSerializer);
+        $internalCache = new LocalCache;
         $atomicCache = new AtomicCache($internalCache, new LocalKeyedMutex);
 
         $atomicCache->set('key', 0);
@@ -187,7 +184,7 @@ class AtomicCacheTest extends AsyncTestCase
         $this->expectException(CacheException::class);
         $this->expectExceptionMessage('Cannot store NULL');
 
-        $cache = new AtomicCache(new SerializedCache(new LocalCache, new PassthroughSerializer), new LocalKeyedMutex);
+        $cache = new AtomicCache(new LocalCache, new LocalKeyedMutex);
         $cache->compute('key', function () {
             return null;
         });
@@ -198,7 +195,7 @@ class AtomicCacheTest extends AsyncTestCase
         $this->expectException(CacheException::class);
         $this->expectExceptionMessage('Cannot store NULL');
 
-        $cache = new AtomicCache(new SerializedCache(new LocalCache, new PassthroughSerializer), new LocalKeyedMutex);
+        $cache = new AtomicCache(new LocalCache, new LocalKeyedMutex);
         $cache->set('key', null);
     }
 
@@ -217,7 +214,7 @@ class AtomicCacheTest extends AsyncTestCase
      */
     public function testComputeCallbackReturningSerializableValue($value): void
     {
-        $cache = new AtomicCache(new SerializedCache(new LocalCache, new NativeSerializer), new LocalKeyedMutex);
+        $cache = new AtomicCache(new LocalCache, new LocalKeyedMutex);
 
         $result = $cache->compute('key', function () use ($value) {
             return $value;
@@ -232,7 +229,7 @@ class AtomicCacheTest extends AsyncTestCase
      */
     public function testComputeCallbackReturningNonString($value): void
     {
-        $cache = new AtomicCache(new SerializedCache(new LocalCache, new NativeSerializer), new LocalKeyedMutex);
+        $cache = new AtomicCache(new LocalCache, new LocalKeyedMutex);
 
         $result = $cache->compute('key', function () use ($value) {
             return $value;
@@ -244,7 +241,7 @@ class AtomicCacheTest extends AsyncTestCase
 
     public function testGetOrDefault(): void
     {
-        $internalCache = new SerializedCache(new LocalCache, new PassthroughSerializer);
+        $internalCache = new LocalCache;
         $atomicCache = new AtomicCache($internalCache, new LocalKeyedMutex);
 
         self::assertSame('default', $atomicCache->get('key', 'default'));
@@ -260,7 +257,7 @@ class AtomicCacheTest extends AsyncTestCase
         $mutex->method('acquire')
             ->willThrowException(new \Exception);
 
-        $cache = new AtomicCache(new SerializedCache(new LocalCache, new PassthroughSerializer), $mutex);
+        $cache = new AtomicCache(new LocalCache, $mutex);
 
         $this->expectException(CacheException::class);
         $this->expectExceptionMessage('Exception thrown when obtaining the lock');
@@ -270,7 +267,7 @@ class AtomicCacheTest extends AsyncTestCase
 
     public function testDelete(): void
     {
-        $internalCache = new SerializedCache(new LocalCache, new PassthroughSerializer);
+        $internalCache = new LocalCache;
         $atomicCache = new AtomicCache($internalCache, new LocalKeyedMutex);
 
         $atomicCache->set('key', 'value');

--- a/test/LocalCacheLimitedTest.php
+++ b/test/LocalCacheLimitedTest.php
@@ -2,10 +2,11 @@
 
 namespace Amp\Cache\Test;
 
-use Amp\Cache\Cache;
 use Amp\Cache\LocalCache;
+use Amp\Cache\StringCache;
+use Amp\Cache\StringCacheAdapter;
 
-class LocalCacheLimitedTest extends CacheTest
+class LocalCacheLimitedTest extends StringCacheTest
 {
     public function testEntryIsNotReturnedAfterCacheLimitReached(): void
     {
@@ -18,8 +19,8 @@ class LocalCacheLimitedTest extends CacheTest
         self::assertNull($cache->get("foo_1"));
     }
 
-    protected function createCache(): Cache
+    protected function createCache(): StringCache
     {
-        return new LocalCache(5, 5);
+        return new StringCacheAdapter(new LocalCache(5, 5));
     }
 }

--- a/test/LocalCacheTest.php
+++ b/test/LocalCacheTest.php
@@ -2,13 +2,14 @@
 
 namespace Amp\Cache\Test;
 
-use Amp\Cache\Cache;
 use Amp\Cache\LocalCache;
+use Amp\Cache\StringCache;
+use Amp\Cache\StringCacheAdapter;
 
-class LocalCacheTest extends CacheTest
+class LocalCacheTest extends StringCacheTest
 {
-    protected function createCache(): Cache
+    protected function createCache(): StringCache
     {
-        return new LocalCache;
+        return new StringCacheAdapter(new LocalCache);
     }
 }

--- a/test/PrefixCacheTest.php
+++ b/test/PrefixCacheTest.php
@@ -2,20 +2,21 @@
 
 namespace Amp\Cache\Test;
 
-use Amp\Cache\Cache;
 use Amp\Cache\LocalCache;
 use Amp\Cache\PrefixCache;
+use Amp\Cache\StringCache;
+use Amp\Cache\StringCacheAdapter;
 
-class PrefixCacheTest extends CacheTest
+class PrefixCacheTest extends StringCacheTest
 {
     public function testPrefix(): void
     {
-        self::assertSame("prefix.", $this->createCache()->getKeyPrefix());
+        self::assertSame("prefix.", (new PrefixCache(new LocalCache, "prefix."))->getKeyPrefix());
     }
 
     /** @return PrefixCache */
-    protected function createCache(): Cache
+    protected function createCache(): StringCache
     {
-        return new PrefixCache(new LocalCache, "prefix.");
+        return new StringCacheAdapter(new PrefixCache(new LocalCache, "prefix."));
     }
 }

--- a/test/SerializedCacheTest.php
+++ b/test/SerializedCacheTest.php
@@ -2,9 +2,9 @@
 
 namespace Amp\Cache\Test;
 
-use Amp\Cache\Cache;
 use Amp\Cache\CacheException;
 use Amp\Cache\SerializedCache;
+use Amp\Cache\StringCache;
 use Amp\PHPUnit\AsyncTestCase;
 use Amp\Serialization\NativeSerializer;
 use Amp\Serialization\SerializationException;
@@ -31,7 +31,7 @@ class SerializedCacheTest extends AsyncTestCase
         $serializer = new NativeSerializer;
         $serializedValue = $serializer->serialize($value);
 
-        $mock = $this->createMock(Cache::class);
+        $mock = $this->createMock(StringCache::class);
 
         $mock->expects(self::once())
             ->method('set')
@@ -57,7 +57,7 @@ class SerializedCacheTest extends AsyncTestCase
         $serializer->method('unserialize')
             ->willThrowException(new SerializationException);
 
-        $mock = $this->createMock(Cache::class);
+        $mock = $this->createMock(StringCache::class);
         $mock->expects(self::once())
             ->method('get')
             ->with('key')
@@ -76,7 +76,7 @@ class SerializedCacheTest extends AsyncTestCase
         $serializer->method('serialize')
             ->willThrowException(new SerializationException);
 
-        $cache = new SerializedCache($this->createMock(Cache::class), $serializer);
+        $cache = new SerializedCache($this->createMock(StringCache::class), $serializer);
 
         $cache->set('key', 'value');
     }
@@ -85,7 +85,7 @@ class SerializedCacheTest extends AsyncTestCase
     {
         $this->expectException(CacheException::class);
 
-        $cache = new SerializedCache($this->createMock(Cache::class), new NativeSerializer);
+        $cache = new SerializedCache($this->createMock(StringCache::class), new NativeSerializer);
 
         $cache->set('key', null);
     }

--- a/test/StringCacheTest.php
+++ b/test/StringCacheTest.php
@@ -2,11 +2,11 @@
 
 namespace Amp\Cache\Test;
 
-use Amp\Cache\Cache;
+use Amp\Cache\StringCache;
 use Amp\PHPUnit\AsyncTestCase;
 use function Amp\delay;
 
-abstract class CacheTest extends AsyncTestCase
+abstract class StringCacheTest extends AsyncTestCase
 {
     public function testGet(): void
     {
@@ -52,5 +52,5 @@ abstract class CacheTest extends AsyncTestCase
         self::assertNull($cache->get("foo"));
     }
 
-    abstract protected function createCache(): Cache;
+    abstract protected function createCache(): StringCache;
 }


### PR DESCRIPTION
Often there's no need to store things as serialized values if only in memory caching is required.