### PR TITLE
Remove get and set from AtomicCache

### DIFF
--- a/src/AtomicCache.php
+++ b/src/AtomicCache.php
@@ -2,7 +2,6 @@
 
 namespace Amp\Cache;
 
-use Amp\Serialization\SerializationException;
 use Amp\Sync\KeyedMutex;
 use Amp\Sync\Lock;
 
@@ -38,7 +37,6 @@ final class AtomicCache
      * @return TValue
      *
      * @throws CacheException If the $create callback throws an exception while generating the value.
-     * @throws SerializationException If serializing the value returned from the callback fails.
      */
     public function compute(string $key, \Closure $compute, ?int $ttl = null): mixed
     {
@@ -65,7 +63,6 @@ final class AtomicCache
      * @return TValue
      *
      * @throws CacheException If the $compute callback throws an exception while generating the value.
-     * @throws SerializationException If serializing the value returned from the callback fails.
      */
     public function computeIfAbsent(string $key, \Closure $compute, ?int $ttl = null): mixed
     {
@@ -97,7 +94,6 @@ final class AtomicCache
      * @return TValue
      *
      * @throws CacheException If the $create callback throws an exception while generating the value.
-     * @throws SerializationException If serializing the value returned from the callback fails.
      */
     public function computeIfPresent(string $key, \Closure $compute, ?int $ttl = null): mixed
     {
@@ -124,62 +120,13 @@ final class AtomicCache
     }
 
     /**
-     * The lock is obtained for the key before setting the value.
-     *
-     * @param string $key Cache key.
-     * @param TValue $value Value to cache.
-     * @param int|null $ttl Timeout in seconds. The default `null` $ttl value indicates no timeout.
-     *
-     * @throws CacheException
-     * @throws SerializationException
-     *
-     * @see SerializedCache::set()
-     */
-    public function set(string $key, mixed $value, ?int $ttl = null): void
-    {
-        $lock = $this->lock($key);
-
-        try {
-            $this->cache->set($key, $value, $ttl);
-        } finally {
-            $lock->release();
-        }
-    }
-
-    /**
-     * Returns the cached value for the key or the given default value if the key does not exist.
-     *
-     * @template TDefault
-     *
-     * @param string $key Cache key.
-     * @param TDefault $default Default value returned if the key does not exist. Null by default.
-     *
-     * @return TValue|TDefault Resolved with null iff $default is null.
-     *
-     * @throws CacheException
-     * @throws SerializationException
-     *
-     * @see SerializedCache::get()
-     */
-    public function get(string $key, mixed $default = null): mixed
-    {
-        $value = $this->cache->get($key);
-
-        if ($value === null) {
-            return $default;
-        }
-
-        return $value;
-    }
-
-    /**
      * The lock is obtained for the key before deleting the key.
      *
      * @param string $key
      *
      * @return bool|null
      *
-     * @see SerializedCache::delete()
+     * @see Cache::delete()
      */
     public function delete(string $key): ?bool
     {

--- a/test/AtomicCacheTest.php
+++ b/test/AtomicCacheTest.php
@@ -162,7 +162,7 @@ class AtomicCacheTest extends AsyncTestCase
         $internalCache = new LocalCache;
         $atomicCache = new AtomicCache($internalCache, new LocalKeyedMutex);
 
-        $atomicCache->set('key', 0);
+        $internalCache->set('key', 0);
 
         $callback = function (string $key, int $value): int {
             $this->assertSame('key', $key);
@@ -190,67 +190,6 @@ class AtomicCacheTest extends AsyncTestCase
         });
     }
 
-    public function testSetNull(): void
-    {
-        $this->expectException(CacheException::class);
-        $this->expectExceptionMessage('Cannot store NULL');
-
-        $cache = new AtomicCache(new LocalCache, new LocalKeyedMutex);
-        $cache->set('key', null);
-    }
-
-    public function provideSerializableValues(): array
-    {
-        return [
-            [new \stdClass],
-            [1],
-            [true],
-            [3.14],
-        ];
-    }
-
-    /**
-     * @dataProvider provideSerializableValues
-     */
-    public function testComputeCallbackReturningSerializableValue($value): void
-    {
-        $cache = new AtomicCache(new LocalCache, new LocalKeyedMutex);
-
-        $result = $cache->compute('key', function () use ($value) {
-            return $value;
-        });
-
-        self::assertEquals($value, $result);
-        self::assertEquals($value, $cache->get('key'));
-    }
-
-    /**
-     * @dataProvider provideSerializableValues
-     */
-    public function testComputeCallbackReturningNonString($value): void
-    {
-        $cache = new AtomicCache(new LocalCache, new LocalKeyedMutex);
-
-        $result = $cache->compute('key', function () use ($value) {
-            return $value;
-        });
-
-        self::assertEquals($value, $result);
-        self::assertEquals($value, $cache->get('key'));
-    }
-
-    public function testGetOrDefault(): void
-    {
-        $internalCache = new LocalCache;
-        $atomicCache = new AtomicCache($internalCache, new LocalKeyedMutex);
-
-        self::assertSame('default', $atomicCache->get('key', 'default'));
-
-        $internalCache->set('key', 'value');
-
-        self::assertSame('value', $atomicCache->get('key', 'default'));
-    }
-
     public function testFailingMutex(): void
     {
         $mutex = $this->createMock(KeyedMutex::class);
@@ -270,7 +209,7 @@ class AtomicCacheTest extends AsyncTestCase
         $internalCache = new LocalCache;
         $atomicCache = new AtomicCache($internalCache, new LocalKeyedMutex);
 
-        $atomicCache->set('key', 'value');
+        $internalCache->set('key', 'value');
 
         $computePromise = async(fn () => $atomicCache->computeIfPresent('key', function (): string {
             return 'new-value';


### PR DESCRIPTION
I believe these methods were originally added with the thought this class should also implement `Cache`, but it doesn't, and as an atomic cache, it likely shouldn't provide methods that could be a footgun.