### PR TITLE
Add Countable and IteratorAggregate interfaces to LocalCache

### DIFF
--- a/test/LocalCacheLimitedTest.php
+++ b/test/LocalCacheLimitedTest.php
@@ -19,6 +19,20 @@ class LocalCacheLimitedTest extends StringCacheTest
         self::assertNull($cache->get("foo_1"));
     }
 
+    public function testLruEntryIsNotReturnedAfterCacheLimitReached(): void
+    {
+        $cache = $this->createCache();
+
+        for ($i = 1; $i <= 5; $i++) {
+            $cache->set("foo_$i", $i, 0);
+        }
+
+        $cache->get("foo_1"); // Touch foo_1 to mark recently used
+        $cache->set("foo_6", 6); // Add another key to exceed cache size limit
+
+        self::assertNull($cache->get("foo_2"));
+    }
+
     protected function createCache(): StringCache
     {
         return new StringCacheAdapter(new LocalCache(5));


### PR DESCRIPTION
Allows LocalCache to be used as traversable LRU cache. We can then replace uses of `cash/lrucache` with our own implementation with little cost.